### PR TITLE
Binding Dr.Hyde with Dr.Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+#Dr.Hyde
+Dr.Hyde/*

--- a/hyde.sh
+++ b/hyde.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+git submodule init
+git submodule update
+cd Dr.Hyde
+if [ ! -d venv ]
+then
+  python3 -m venv venv
+  . venv/bin/activate
+  pip install --upgrade pip
+  pip install -r test-requirements.txt -r requirements.txt
+  git clone https://github.com/boolsajo/PyHtml2Md
+  cd PyHtml2Md
+  python setup.py install
+  echo 'Install complete'
+else
+  echo 'Nothing to install'
+fi
+exit 0 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/node": "7.0.7",
     "autoprefixer": "7.1.1",
     "codelyzer": "3.1.1",
+    "copy-webpack-plugin": "^4.2.1",
     "copyfiles": "1.2.0",
     "cross-env": "5.0.1",
     "css-loader": "0.28.4",

--- a/src/app/jekyll.service.ts
+++ b/src/app/jekyll.service.ts
@@ -2,11 +2,13 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs/Subject';
 
+import * as path from 'path';
 import * as cp from 'child_process';
 
 @Injectable()
 export class JekyllService {
   private jekyll : cp.ChildProcess;
+  private hyde : cp.ChildProcess;
   private subject = new Subject<any>();
 
   constructor() {}
@@ -17,12 +19,32 @@ export class JekyllService {
     return this.jekyll;
   }
 
+  // Fix me : Need error exception for running error
+  runHyde(path) {
+    // Fix me : Dr.Hyde path have to be under dist. Not on the project path.
+    // So it must be like
+    // cd path && . venv/bin/activate && python manage.py runserver
+    let command = 'cd '+ path +' && cd ../Dr.Hyde && . venv/bin/activate && python manage.py runserver';
+
+    this.hyde = cp.exec(command);
+    
+    return this.hyde;
+  }
+
+  passHydeProcess(ps){
+    this.subject.next(ps);
+  }
+
   passJekyllProcess(ps){
     this.subject.next(ps);
   }
 
   getJekyll(){
     return this.jekyll;
+  }
+
+  getHyde(){
+    return this.hyde;
   }
 
   getJekyllProcess(): Observable<any> {

--- a/src/app/start/start.component.ts
+++ b/src/app/start/start.component.ts
@@ -35,6 +35,7 @@ export class StartComponent implements OnInit {
     win.setMaximizable(false);
     win.setSize(780,480,true);
     this.preventDragandDrop();
+    this.runHyde();
   };
 
   navigateToLogin() {
@@ -75,6 +76,18 @@ export class StartComponent implements OnInit {
       this.router.navigate(['/editor',{'src' : result.path }]);
       this.jekyllService.passJekyllProcess(result.child);
     }
+  }
+
+  private runHyde(){
+    let appPath = remote.app.getAppPath();
+    let child = this.jekyllService.runHyde(appPath);
+
+    child.stdout.on('data', data => {
+      console.log(data);
+      if(data.toString().indexOf('Running on http://127.0.0.1:5000/') !== -1){
+        console.log('hyde is running')
+      }
+    });
   }
 
   private preventDragandDrop() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ const postcssUrl = require('postcss-url');
 
 const { NoEmitOnErrorsPlugin, LoaderOptionsPlugin, DefinePlugin, HashedModuleIdsPlugin } = require('webpack');
 const { GlobCopyWebpackPlugin, BaseHrefWebpackPlugin } = require('@angular/cli/plugins/webpack');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { CommonsChunkPlugin, UglifyJsPlugin } = require('webpack').optimize;
 const { AotPlugin } = require('@ngtools/webpack');
 


### PR DESCRIPTION
To integrate Dr.Hyde and Dr.Jekyll, Dr.Hyde must be child process of Dr.Jekyll.
This patch is implementing running Dr.Hyde as child process of Dr.Jekyll.

There are still some issues. Find the `Fix me` comments.

Issue #6, #15